### PR TITLE
Add get deleted to vendors, accounts, and bills

### DIFF
--- a/lib/netsuite/records/account.rb
+++ b/lib/netsuite/records/account.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :update, :delete, :search, :upsert
+      actions :get, :get_list, :get_deleted, :add, :update, :delete, :search, :upsert
 
       fields :acct_name, :acct_number, :acct_type, :cash_flow_rate, :cur_doc_num, :description, :eliminate, :exchange_rate,
         :general_rate, :include_children, :inventory, :is_inactive, :opening_balance, :revalue, :tran_date, :balance

--- a/lib/netsuite/records/vendor.rb
+++ b/lib/netsuite/records/vendor.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListRel
 
-      actions :get, :get_list, :add, :update, :upsert, :delete, :search
+      actions :get, :get_list, :get_deleted, :add, :update, :upsert, :delete, :search
 
       fields :account_number, :alt_email, :alt_name, :alt_phone,
              :bcn, :bill_pay, :comments, :company_name, :credit_limit,

--- a/lib/netsuite/records/vendor_bill.rb
+++ b/lib/netsuite/records/vendor_bill.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::TranPurch
 
-      actions :add, :delete, :get, :get_list, :get_select_value, :initialize, :search, :update, :upsert, :upsert_list
+      actions :add, :delete, :get, :get_list, :get_deleted, :get_select_value, :initialize, :search, :update, :upsert, :upsert_list
 
       fields :created_date, :credit_limit, :currency_name, :discount_amount, :discount_date, :due_date, :exchange_rate,
              :landed_costs_list, :landed_cost_method, :landed_cost_per_line, :last_modified_date, :memo, :tax_total,


### PR DESCRIPTION
- Add get deleted to vendors, accounts, and bills
- It's really the same call for all of them (you just filter by type on your own, which is a dumb design but the one we are somewhat locked into with this library). It will be nice to make the call from the specific "service" regardless