### PR TITLE
Added update action to non-inventory purchase item

### DIFF
--- a/lib/netsuite/records/non_inventory_purchase_item.rb
+++ b/lib/netsuite/records/non_inventory_purchase_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update_list, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update_list, :upsert, :update
 
       fields :available_to_partners, :cost, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :country_of_manufacture,
         :created_date, :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap,


### PR DESCRIPTION
- Sorbet alerted me that "Non-Inventory Purchase Item" was missing the `update` action, so added here
<img width="955" alt="CleanShot 2023-08-11 at 12 47 55@2x" src="https://github.com/team-settle/netsuite/assets/7988788/78f3438b-42c9-4550-8500-e0de71b12d3f">
